### PR TITLE
Loosen up json dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,10 @@
 source "http://rubygems.org"
 
-gem "json", "~> 1.4.6"
+gem "json", "~> 1.4"
 gem "curb", "~> 0.7.8"
 
 group :development do
   gem "bundler", "~> 1.0.0"
   gem "jeweler", "~> 1.5.1"
-  gem "json", "~> 1.4.6"
-  gem "curb", "~> 0.7.8"
 end
 


### PR DESCRIPTION
Ran into this today where pagerduty specified `~> 1.4.6` and another library used `~> 1.6.1`, causing the dreaded `Gem::LoadError`.

The best way to work around this is to use `~>` for the minor version instead of the patch version.
