### PR TITLE
Fix details getting overridden when doing the API call

### DIFF
--- a/lib/pagerduty.rb
+++ b/lib/pagerduty.rb
@@ -63,14 +63,14 @@ class PagerdutyIncident < Pagerduty
   end
 
   def acknowledge(description, details = {})
-    resp = api_call("acknowledge", description, details = {})
+    resp = api_call("acknowledge", description, details)
     throw PagerdutyException.new(self, resp) unless resp["status"] == "success"
 
     self
   end
 
   def resolve(description, details = {})
-    resp = api_call("resolve", description, details = {})
+    resp = api_call("resolve", description, details)
     throw PagerdutyException.new(self, resp) unless resp["status"] == "success"
 
     self


### PR DESCRIPTION
Only a small fix: when providing details to API calls, the details hash was overridden by an empty Hash. 
