### PR TITLE
Changed dependency on json to allow recent versions to be used

### DIFF
--- a/lib/pagerduty/version.rb
+++ b/lib/pagerduty/version.rb
@@ -1,3 +1,3 @@
 class Pagerduty
-  VERSION = "1.3.2"
+  VERSION = "1.3.3"
 end

--- a/pagerduty.gemspec
+++ b/pagerduty.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency "json", ["~> 1.4.6"]
+  gem.add_runtime_dependency "json", ["~> 1.4"]
 end


### PR DESCRIPTION
Changed dependency on json from requiring ~> 1.4.6 to just ~> 1.4 allowing version 1.7.5 (current stable) to be used.
