### PR TITLE
Error management

### DIFF
--- a/lib/pagerduty.rb
+++ b/lib/pagerduty.rb
@@ -4,9 +4,10 @@ require 'pagerduty/http_transport'
 class PagerdutyException < StandardError
   attr_reader :pagerduty_instance, :api_response
 
-  def initialize(instance, resp)
+  def initialize(instance, response, message)
+    super(message)
     @pagerduty_instance = instance
-    @api_response = resp
+    @api_response = response
   end
 end
 
@@ -40,7 +41,7 @@ protected
 
   def ensure_success(response)
     unless response["status"] == "success"
-      raise PagerdutyException.new(self, response)
+      raise PagerdutyException.new(self, response, response["message"])
     end
   end
 

--- a/spec/pagerduty_spec.rb
+++ b/spec/pagerduty_spec.rb
@@ -254,10 +254,12 @@ describe Pagerduty do
   describe PagerdutyException do
     Given(:pagerduty_instance) { double }
     Given(:api_response) { double }
+    Given(:message) { "a test error message" }
 
-    When(:pagerduty_exception) { PagerdutyException.new(pagerduty_instance, api_response) }
+    When(:pagerduty_exception) { PagerdutyException.new(pagerduty_instance, api_response, message) }
 
     Then { pagerduty_exception.pagerduty_instance == pagerduty_instance }
     Then { pagerduty_exception.api_response == api_response }
+    Then { pagerduty_exception.message == message }
   end
 end


### PR DESCRIPTION
- Expose PagerDuty's error message in the raised exception.
- `PagerdutyException` extends `StandardError` rather than `Exception`
