### PR TITLE
Print Ruby warnings to the console

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,7 @@ task default: [:rubocop, :spec]
 
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.verbose = false
+  t.ruby_opts = '-w'
 end
 
 desc "rubocop compliancy checks"

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ task default: [:rubocop, :spec]
 
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.verbose = false
-  t.ruby_opts = '-w'
+  t.ruby_opts = "-w"
 end
 
 desc "rubocop compliancy checks"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,13 @@
 # encoding: utf-8
-require "pagerduty"
-require "rspec/given"
-
 Dir[File.expand_path("../support/**/*.rb", __FILE__)].each { |f| require f }
+
+Warnings.silenced do
+  require "rspec/given"
+  require "json"
+  require "net/https"
+end
+
+require "pagerduty"
 
 RSpec.configure do |config|
   config.color = true

--- a/spec/support/warnings.rb
+++ b/spec/support/warnings.rb
@@ -1,0 +1,12 @@
+module Warnings
+  def self.silenced(&block)
+    with_flag(nil, &block)
+  end
+
+  def self.with_flag(flag)
+    old_verbose, $VERBOSE = $VERBOSE, flag
+    yield
+  ensure
+    $VERBOSE = old_verbose
+  end
+end


### PR DESCRIPTION
Print Ruby warnings to the console during our test run. We don't want this gem producing warning as that would frustrate projects downstream.

If we notice any warnings, they should be fixed.