### PR TITLE
Rubocop adjustments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ AllCops:
   Exclude:
     - .bundle/**/*
     - bin/**/*
+    - vendor/**/*
 
 Style/AccessModifierIndentation:
   EnforcedStyle: outdent

--- a/pagerduty.gemspec
+++ b/pagerduty.gemspec
@@ -28,5 +28,5 @@ https://github.com/envato/pagerduty#upgrading-to-version-200
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec-given"
-  gem.add_development_dependency "rubocop"
+  gem.add_development_dependency "rubocop", "0.34.2"
 end


### PR DESCRIPTION
* Let's pin Rubocop to a specific version. So new cops won't inconveniently break our build.
* Let's not let Rubocop police the vendor directory as that's not our code.