### PR TITLE
Provide an explicit API for HTTP proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,25 @@ pagerduty.trigger(
 )
 ```
 
+### HTTP Proxy Support
+
+One can explicitly define an HTTP proxy like this:
+
+```ruby
+# Instantiate a Pagerduty with your specific service key and proxy details
+pagerduty = Pagerduty.new(
+  "<my-service-key>",
+  proxy_host: "my.http.proxy.local",
+  proxy_port: 3128,
+  proxy_username: "<my-proxy-username>",
+  proxy_password: "<my-proxy-password>",
+)
+
+# Then proceed to trigger your incident
+# (sends the request to PagerDuty via the HTTP proxy)
+incident = pagerduty.trigger("incident description")
+```
+
 ### Debugging Error Responses
 
 The gem doesn't encapsulate HTTP error responses from PagerDuty. Here's how to

--- a/lib/pagerduty/http_transport.rb
+++ b/lib/pagerduty/http_transport.rb
@@ -4,25 +4,31 @@ require "net/https"
 
 class Pagerduty
   # @api private
-  module HttpTransport
+  class HttpTransport
     HOST = "events.pagerduty.com"
     PORT = 443
     PATH = "/generic/2010-04-15/create_event.json"
 
-    def self.send_payload(payload = {})
+    def initialize(options = {})
+      @options = options
+    end
+
+    def send_payload(payload = {})
       response = post payload.to_json
       response.error! unless transported?(response)
       JSON.parse(response.body)
     end
 
-    def self.post(payload)
+  private
+
+    def post(payload)
       post = Net::HTTP::Post.new(PATH)
       post.body = payload
       http.request(post)
     end
 
-    def self.http
-      http = Net::HTTP.new(HOST, PORT)
+    def http
+      http = http_proxy.new(HOST, PORT)
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_PEER
       http.open_timeout = 60
@@ -30,10 +36,17 @@ class Pagerduty
       http
     end
 
-    def self.transported?(response)
-      response.is_a?(Net::HTTPSuccess) || response.is_a?(Net::HTTPRedirection)
+    def http_proxy
+      Net::HTTP.Proxy(
+        @options[:proxy_host],
+        @options[:proxy_port],
+        @options[:proxy_username],
+        @options[:proxy_password],
+      )
     end
 
-    private_class_method :post, :http, :transported?
+    def transported?(response)
+      response.is_a?(Net::HTTPSuccess) || response.is_a?(Net::HTTPRedirection)
+    end
   end
 end

--- a/spec/pagerduty/http_transport_spec.rb
+++ b/spec/pagerduty/http_transport_spec.rb
@@ -2,12 +2,14 @@
 require "spec_helper"
 
 describe Pagerduty::HttpTransport do
-  Given(:http_transport) { Pagerduty::HttpTransport }
+  Given(:http_transport) { Pagerduty::HttpTransport.new(options) }
 
-  Given(:http) { double.as_null_object }
+  Given(:options) { {} }
+  Given(:http) { spy }
+  Given(:http_proxy) { spy(new: http) }
   Given { allow(http).to receive(:request).and_return(standard_response) }
-  Given { allow(Net::HTTP).to receive(:new).and_return(http) }
-  Given(:post) { double.as_null_object }
+  Given { allow(Net::HTTP).to receive(:Proxy).and_return(http_proxy) }
+  Given(:post) { spy }
   Given { allow(Net::HTTP::Post).to receive(:new).and_return(post) }
 
   describe "::send_payload" do
@@ -82,6 +84,27 @@ describe Pagerduty::HttpTransport do
         expect(http)
           .to have_received(:verify_mode=)
           .with(OpenSSL::SSL::VERIFY_PEER)
+      }
+    end
+
+    describe "proxy use" do
+      Given(:options) {
+        {
+          proxy_host: "test-proxy-host",
+          proxy_port: "test-proxy-port",
+          proxy_username: "test-proxy-username",
+          proxy_password: "test-proxy-password",
+        }
+      }
+      Then {
+        expect(Net::HTTP)
+          .to have_received(:Proxy)
+          .with(
+            "test-proxy-host",
+            "test-proxy-port",
+            "test-proxy-username",
+            "test-proxy-password",
+          )
       }
     end
 


### PR DESCRIPTION
Allows an HTTP proxy to be configured via initializer options. Great for those behind a corporate firewall.

Fixes #45.