### PR TITLE
Adopt PagerDuty's new API 2.0

### DIFF
--- a/lib/pagerduty/http_transport.rb
+++ b/lib/pagerduty/http_transport.rb
@@ -7,7 +7,7 @@ class Pagerduty
   class HttpTransport
     HOST = "events.pagerduty.com".freeze
     PORT = 443
-    PATH = "/generic/2010-04-15/create_event.json".freeze
+    PATH = "/v2/enqueue".freeze
 
     def initialize(options = {})
       @options = options

--- a/lib/pagerduty/version.rb
+++ b/lib/pagerduty/version.rb
@@ -1,3 +1,3 @@
 class Pagerduty
-  VERSION = "2.1.1".freeze
+  VERSION = "3.0.0".freeze
 end

--- a/pagerduty.gemspec
+++ b/pagerduty.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |gem|
   gem.license       = "MIT"
 
   gem.post_install_message = %(
-If upgrading to pagerduty 2.0.0 please note the API changes:
-https://github.com/envato/pagerduty#upgrading-to-version-200
+If upgrading to pagerduty 3.0.0 please note the API changes:
+https://github.com/envato/pagerduty#upgrading-to-version-300
   )
 
   gem.files         = `git ls-files`.split($/)

--- a/spec/pagerduty/http_transport_spec.rb
+++ b/spec/pagerduty/http_transport_spec.rb
@@ -15,7 +15,7 @@ describe Pagerduty::HttpTransport do
   describe "::send_payload" do
     Given(:payload) {
       {
-        event_type: "trigger",
+        event_action: "trigger",
         service_key: "test-srvc-key",
         description: "test-desc",
         details: { key: "value" },
@@ -27,7 +27,7 @@ describe Pagerduty::HttpTransport do
     describe "provides the correct request" do
       Then {
         expect(post).to have_received(:body=).with(
-          '{"event_type":"trigger",'\
+          '{"event_action":"trigger",'\
           '"service_key":"test-srvc-key",'\
           '"description":"test-desc",'\
           '"details":{"key":"value"}}',
@@ -116,7 +116,9 @@ describe Pagerduty::HttpTransport do
 
   def standard_response
     response_with_body(
-      '{ "status": "success", "incident_key": "My Incident Key" }',
+      '{ "status": "success", \
+      "message": "MY MESSAGE", \
+      "dedup_key": "my-dedup-key" }',
     )
   end
 

--- a/spec/pagerduty_spec.rb
+++ b/spec/pagerduty_spec.rb
@@ -2,9 +2,9 @@
 require "spec_helper"
 
 describe Pagerduty do
-  Given(:pagerduty) { Pagerduty.new(service_key, options) }
+  Given(:pagerduty) { Pagerduty.new(routing_key, options) }
 
-  Given(:service_key) { "a-test-service-key" }
+  Given(:routing_key) { "a-test-routing-key" }
   Given(:options) { { transport: transport } }
   Given(:transport) { spy }
 
@@ -17,35 +17,66 @@ describe Pagerduty do
       }
 
       context "no options" do
-        When(:incident) { pagerduty.trigger("a-test-description") }
+        When(:incident) { pagerduty.trigger }
         Then {
-          expect(transport).to have_received(:send_payload).with(
-            service_key: "a-test-service-key",
-            event_type:  "trigger",
-            description: "a-test-description",
-          )
+          expect(incident).to have_raised ArgumentError
         }
       end
 
       context "all options" do
         When(:incident) {
           pagerduty.trigger(
-            "a-test-description",
-            incident_key: "a-test-incident-key",
-            client:       "a-test-client",
-            client_url:   "a-test-client-url",
-            details:      { key: "value" },
+            summary: "summary",
+            source: "source",
+            severity: "critical",
+            timestamp: "timestamp",
+            component: "component",
+            group: "group",
+            class: "class",
+            custom_details: {
+              random: "random",
+            },
+            images: [{
+              src: "http://via.placeholder.com/350x150",
+              href: "https://example.com/",
+              alt: "Example text",
+            }],
+            links: [{
+              href: "https://example.com/",
+              text: "Link text",
+            }],
+            client: "Sample Monitoring Service",
+            client_url: "https://monitoring.example.com",
           )
         }
         Then {
           expect(transport).to have_received(:send_payload).with(
-            service_key:  "a-test-service-key",
-            event_type:   "trigger",
-            description:  "a-test-description",
-            incident_key: "a-test-incident-key",
-            client:       "a-test-client",
-            client_url:   "a-test-client-url",
-            details:      { key: "value" },
+            routing_key: "a-test-routing-key",
+            event_action: "trigger",
+            dedup_key: nil,
+            payload: {
+              summary: "summary",
+              source: "source",
+              severity: "critical",
+              timestamp: "timestamp",
+              component: "component",
+              group: "group",
+              class: "class",
+              custom_details: {
+                random: "random",
+              },
+            },
+            images: [{
+              src: "http://via.placeholder.com/350x150",
+              href: "https://example.com/",
+              alt: "Example text",
+            }],
+            links: [{
+              href: "https://example.com/",
+              text: "Link text",
+            }],
+            client: "Sample Monitoring Service",
+            client_url: "https://monitoring.example.com",
           )
         }
       end
@@ -80,26 +111,24 @@ describe Pagerduty do
       context "PagerDuty successfully creates the incident" do
         Given {
           allow(transport).to receive(:send_payload).and_return(
-            "status" => "success",
-            "incident_key" => "My Incident Key",
-            "message" => "Event processed",
+            standard_response,
           )
         }
-        When(:incident) { pagerduty.trigger("description") }
+        When(:incident) { pagerduty.trigger(min_req_input) }
         Then { expect(incident).to be_a PagerdutyIncident }
-        Then { incident.service_key == service_key }
-        Then { incident.incident_key == "My Incident Key" }
+        Then { incident.routing_key == routing_key }
+        Then { incident.dedup_key == "my-dedup-key" }
         Then { incident.instance_variable_get("@transport") == transport }
       end
 
       context "PagerDuty fails to create the incident" do
         Given {
           allow(transport).to receive(:send_payload).and_return(
-            "status" => "failure",
-            "message" => "Event not processed",
+            "status" => "invalid event",
+            "message" => "Event object is invalid",
           )
         }
-        When(:incident) { pagerduty.trigger("description") }
+        When(:incident) { pagerduty.trigger(min_req_input) }
         Then { expect(incident).to have_raised PagerdutyException }
       end
 
@@ -109,34 +138,34 @@ describe Pagerduty do
             .to receive(:send_payload)
             .and_raise(Net::HTTPServerException.new(nil, nil))
         }
-        When(:incident) { pagerduty.trigger("description") }
+        When(:incident) { pagerduty.trigger(min_req_input) }
         Then { expect(incident).to have_raised Net::HTTPServerException }
       end
     end
   end
 
   describe "#get_incident" do
-    When(:incident) { pagerduty.get_incident(incident_key) }
+    When(:incident) { pagerduty.get_incident(dedup_key) }
 
     context "a valid incident_key" do
-      Given(:incident_key) { "a-test-incident-key" }
+      Given(:dedup_key) { "a-test-dedup-key" }
       Then { expect(incident).to be_a PagerdutyIncident }
-      Then { incident.service_key == service_key }
-      Then { incident.incident_key == incident_key }
+      Then { incident.routing_key == routing_key }
+      Then { incident.dedup_key == dedup_key }
       Then { incident.instance_variable_get("@transport") == transport }
     end
 
     context "a nil incident_key" do
-      Given(:incident_key) { nil }
+      Given(:dedup_key) { nil }
       Then { expect(incident).to have_failed ArgumentError }
     end
   end
 
   describe PagerdutyIncident do
     Given(:incident) {
-      PagerdutyIncident.new(service_key, incident_key, options)
+      PagerdutyIncident.new(routing_key, dedup_key, options)
     }
-    Given(:incident_key) { "a-test-incident-key" }
+    Given(:dedup_key) { "a-test-dedup-key" }
 
     describe "#acknowledge" do
       describe "provides the correct request" do
@@ -150,9 +179,13 @@ describe Pagerduty do
           When(:acknowledge) { incident.acknowledge }
           Then {
             expect(transport).to have_received(:send_payload).with(
-              event_type: "acknowledge",
-              service_key: "a-test-service-key",
-              incident_key: "a-test-incident-key",
+              event_action: "acknowledge",
+              routing_key: "a-test-routing-key",
+              dedup_key: "a-test-dedup-key",
+              images: nil,
+              links: nil,
+              client: nil,
+              client_url: nil,
             )
           }
         end
@@ -160,12 +193,7 @@ describe Pagerduty do
         context "a description" do
           When(:acknowledge) { incident.acknowledge("test-description") }
           Then {
-            expect(transport).to have_received(:send_payload).with(
-              event_type: "acknowledge",
-              service_key: "a-test-service-key",
-              incident_key: "a-test-incident-key",
-              description: "test-description",
-            )
+            expect(acknowledge).to have_failed ArgumentError
           }
         end
 
@@ -174,13 +202,7 @@ describe Pagerduty do
             incident.acknowledge("test-description", my: "detail")
           }
           Then {
-            expect(transport).to have_received(:send_payload).with(
-              event_type: "acknowledge",
-              service_key: "a-test-service-key",
-              incident_key: "a-test-incident-key",
-              description: "test-description",
-              details: { my: "detail" },
-            )
+            expect(acknowledge).to have_failed ArgumentError
           }
         end
       end
@@ -189,9 +211,7 @@ describe Pagerduty do
         context "PagerDuty successfully acknowledges the incident" do
           Given {
             allow(transport).to receive(:send_payload).and_return(
-              "status" => "success",
-              "incident_key" => "a-test-incident-key",
-              "message" => "Event acknowledged",
+              standard_response,
             )
           }
           When(:acknowledge) { incident.acknowledge }
@@ -201,9 +221,8 @@ describe Pagerduty do
         context "PagerDuty fails to acknowledge the incident" do
           Given {
             allow(transport).to receive(:send_payload).and_return(
-              "status" => "failure",
-              "incident_key" => "a-test-incident-key",
-              "message" => "Event not acknowledged",
+              "status" => "invalid event",
+              "message" => "Event object is invalid",
             )
           }
           When(:acknowledge) { incident.acknowledge }
@@ -234,9 +253,13 @@ describe Pagerduty do
           When(:resolve) { incident.resolve }
           Then {
             expect(transport).to have_received(:send_payload).with(
-              event_type: "resolve",
-              service_key: "a-test-service-key",
-              incident_key: "a-test-incident-key",
+              event_action: "resolve",
+              routing_key: "a-test-routing-key",
+              dedup_key: "a-test-dedup-key",
+              images: nil,
+              links: nil,
+              client: nil,
+              client_url: nil,
             )
           }
         end
@@ -244,25 +267,14 @@ describe Pagerduty do
         context "a description" do
           When(:resolve) { incident.resolve("test-description") }
           Then {
-            expect(transport).to have_received(:send_payload).with(
-              event_type: "resolve",
-              service_key: "a-test-service-key",
-              incident_key: "a-test-incident-key",
-              description: "test-description",
-            )
+            expect(resolve).to have_failed ArgumentError
           }
         end
 
         context "a description and details" do
           When(:resolve) { incident.resolve("test-description", my: "detail") }
           Then {
-            expect(transport).to have_received(:send_payload).with(
-              event_type: "resolve",
-              service_key: "a-test-service-key",
-              incident_key: "a-test-incident-key",
-              description: "test-description",
-              details: { my: "detail" },
-            )
+            expect(resolve).to have_failed ArgumentError
           }
         end
       end
@@ -271,9 +283,7 @@ describe Pagerduty do
         context "PagerDuty successfully resolves the incident" do
           Given {
             allow(transport).to receive(:send_payload).and_return(
-              "status" => "success",
-              "incident_key" => "a-test-incident-key",
-              "message" => "Event resolved",
+              standard_response,
             )
           }
           When(:resolve) { incident.resolve }
@@ -283,8 +293,8 @@ describe Pagerduty do
         context "PagerDuty fails to create the incident" do
           Given {
             allow(transport).to receive(:send_payload).and_return(
-              "status" => "failure",
-              "message" => "Event not resolved",
+              "status" => "invalid event",
+              "message" => "Event object is invalid",
             )
           }
           When(:resolve) { incident.resolve }
@@ -311,15 +321,31 @@ describe Pagerduty do
             .and_return(standard_response)
         }
 
-        context "no options" do
-          Given(:incident_key) { "instance incident_key" }
+        context "incorrect parameter type" do
+          Given(:dedup_key) { "instance dedup_key" }
           When(:trigger) { incident.trigger("description") }
           Then {
+            expect(trigger).to have_failed TypeError
+          }
+        end
+
+        context "no options" do
+          Given(:dedup_key) { "instance dedup_key" }
+          When(:trigger) { incident.trigger(min_req_input) }
+          Then {
             expect(transport).to have_received(:send_payload).with(
-              incident_key: "instance incident_key",
-              service_key:  "a-test-service-key",
-              event_type:   "trigger",
-              description:  "description",
+              routing_key:  "a-test-routing-key",
+              dedup_key: "instance dedup_key",
+              event_action:   "trigger",
+              images: nil,
+              links: nil,
+              client: nil,
+              client_url: nil,
+              payload: {
+                summary: "summary",
+                source: "source",
+                severity: "critical",
+              },
             )
           }
         end
@@ -327,16 +353,18 @@ describe Pagerduty do
         context "with incident_key option" do
           When(:trigger) {
             incident.trigger(
-              "description",
-              incident_key: "method param incident_key",
+              dedup_key: "instance dedup_key",
             )
           }
           Then {
             expect(transport).to have_received(:send_payload).with(
-              incident_key: "method param incident_key",
-              service_key:  "a-test-service-key",
-              event_type:   "trigger",
-              description:  "description",
+              routing_key:  "a-test-routing-key",
+              dedup_key: "instance dedup_key",
+              event_action:   "trigger",
+              images: nil,
+              links: nil,
+              client: nil,
+              client_url: nil,
             )
           }
         end
@@ -345,7 +373,19 @@ describe Pagerduty do
   end
 
   def standard_response
-    { "status" => "success", "incident_key" => "My Incident Key" }
+    {
+      "status" => "success",
+      "message" => "MY MESSAGE",
+      "dedup_key" => "my-dedup-key",
+    }
+  end
+
+  def min_req_input
+    {
+      summary: "summary",
+      source: "source",
+      severity: "critical",
+    }
   end
 
   describe PagerdutyException do


### PR DESCRIPTION
Starting April 28th, PagerDuty will stop issuing API tokens for their v1 API service. 

On October 19th, PagerDuty will decommission their v1 API service.

https://v2.developer.pagerduty.com/docs/v1-rest-api-decommissioning-faq

I have adapted the current gem code to support the new syntax of PagerDuty's API v2 service.