### PR TITLE
Remove leading and trailing whitespace in post_install_message

### DIFF
--- a/lib/pagerduty/http_transport.rb
+++ b/lib/pagerduty/http_transport.rb
@@ -1,4 +1,3 @@
-
 require "json"
 require "net/https"
 

--- a/pagerduty.gemspec
+++ b/pagerduty.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.post_install_message = %(
 If upgrading to pagerduty 2.0.0 please note the API changes:
 https://github.com/envato/pagerduty#upgrading-to-version-200
-  )
+  ).gsub(/\A\s+|\s+\z/, "")
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }

--- a/pagerduty.gemspec
+++ b/pagerduty.gemspec
@@ -1,4 +1,3 @@
-
 lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "pagerduty/version"

--- a/spec/pagerduty/http_transport_spec.rb
+++ b/spec/pagerduty/http_transport_spec.rb
@@ -1,4 +1,3 @@
-
 require "spec_helper"
 
 describe Pagerduty::HttpTransport do

--- a/spec/pagerduty_spec.rb
+++ b/spec/pagerduty_spec.rb
@@ -1,4 +1,3 @@
-
 require "spec_helper"
 
 describe Pagerduty do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-
 Dir[File.expand_path("support/**/*.rb", __dir__)].each { |f| require f }
 
 Warnings.silenced do


### PR DESCRIPTION
This has always bugged me when installing this gem.

Another way of doing it could be:
```ruby
  gem.post_install_message =
%(If upgrading to pagerduty 2.0.0 please note the API changes:
https://github.com/envato/pagerduty#upgrading-to-version-200)
```