### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,10 @@ Metrics/BlockLength:
   Exclude:
     - spec/**/*
 
+Metrics/LineLength:
+  Exclude:
+    - pagerduty.gemspec
+
 Style/BlockDelimiters:
   Exclude:
     - spec/**/*

--- a/pagerduty.gemspec
+++ b/pagerduty.gemspec
@@ -15,6 +15,12 @@ Gem::Specification.new do |gem|
   gem.homepage      = "http://github.com/envato/pagerduty"
   gem.license       = "MIT"
 
+  gem.metadata      = {
+    "bug_tracker_uri"   => "https://github.com/envato/pagerduty/issues",
+    "documentation_uri" => "https://www.rubydoc.info/gems/pagerduty/#{gem.version}",
+    "source_code_uri"   => "https://github.com/envato/pagerduty/tree/v#{gem.version}",
+  }
+
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
Add [project metadata](https://guides.rubygems.org/specification-reference/#metadata) to the gemspec file. This'll allow people to more easily access the source code, raise issues and read the changelog. These `bug_tracker_uri`, `documentation_uri` and `source_code_uri` links will appear on the rubygems page at https://rubygems.org/gems/pagerduty and be available via the rubygems API after the next release.