### PR TITLE
Don't include test files in the packaged gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,17 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 - Realign with latest Rubocop style ([#54]).
 
+### Removed
+
+- Test files are no longer included in the gem file ([#60]).
+
 [Unreleased]: https://github.com/envato/pagerduty/compare/v2.1.2...HEAD
 [#54]: https://github.com/envato/pagerduty/pull/54
 [#55]: https://github.com/envato/pagerduty/pull/55
 [#57]: https://github.com/envato/pagerduty/pull/57
 [#58]: https://github.com/envato/pagerduty/pull/58
 [#59]: https://github.com/envato/pagerduty/pull/59
+[#60]: https://github.com/envato/pagerduty/pull/60
 
 ## [2.1.2] - 2018-09-18
 

--- a/pagerduty.gemspec
+++ b/pagerduty.gemspec
@@ -22,10 +22,10 @@ Gem::Specification.new do |gem|
     "source_code_uri"   => "https://github.com/envato/pagerduty/tree/v#{gem.version}",
   }
 
-  gem.files         = `git ls-files`.split($/)
-  gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
+  gem.files         = `git ls-files -z`.split("\x0").select do |f|
+    f.match(%r{^(?:README|LICENSE|CHANGELOG|lib/)})
+  end
 
   gem.add_runtime_dependency "json", ">= 1.7.7"
   gem.add_development_dependency "bundler"


### PR DESCRIPTION
There seems no point to include the test files in the packaged gem. There is little to no development on the `pagerduty` gem release itself. Rather new features will be developed and test suite run on the source obtained from this git repository.

Let's not include the specs and files supporting the test suite in the gem.

This reduces the gem package size from 14K to 8.5K.