### PR TITLE
Rubocop fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Fixed
 
-- Realign with latest Rubocop style ([#54]).
+- Realign with latest Rubocop style ([#54], [#62]).
 
 ### Removed
 
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 [#58]: https://github.com/envato/pagerduty/pull/58
 [#59]: https://github.com/envato/pagerduty/pull/59
 [#60]: https://github.com/envato/pagerduty/pull/60
+[#62]: https://github.com/envato/pagerduty/pull/62
 
 ## [2.1.2] - 2018-09-18
 

--- a/pagerduty.gemspec
+++ b/pagerduty.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec-given"
-  gem.add_development_dependency "rubocop"
+  gem.add_development_dependency "rubocop", " < 0.77"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Dir[File.expand_path("support/**/*.rb", __dir__)].each { |f| require f }
+Dir[File.expand_path("support/**/*.rb", __dir__)].sort.each { |f| require f }
 
 Warnings.silenced do
   require "rspec/given"


### PR DESCRIPTION
#### Context

The CI build tests against Ruby 2.1 and 2.2. On these Ruby versions, we use older versions of Rubocop (0.57.2 and 0.68.1 respectively) because newer versions of Rubocop have dropped support for these older Ruby versions. As such we need a Rubocop config that supports these old versions.

The latest versions of Rubocop have introduced cop name changes that breaks our `.rubocop.yml` config. If we make the required changes to the config, these older versions of Rubocop will error.

#### Change

Pin Rubocop to the latest version that supports our `.rubocop.yml` configuration.

#### Consequences

This allows us to continue supporting these old versions of Ruby.

When we drop support for Ruby 2.1 and 2.2, we can investigate unpinning this gem.