### PR TITLE
Replace #get_incident with #incident

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,18 @@ The format is based on [Keep a Changelog], and this project adheres to
   incident.resolve
   ```
 
+- Added an `incident` method to the Pagerduty Events API V1 instance ([#67]).
+  This is intended as a drop-in replacement for the now-deprecated
+  `get_incident` method.
+
+  ```ruby
+  pagerduty = Pagerduty.build(
+    integration_key: "<integration-key>",
+    api_version:     1
+  )
+  incident = pagerduty.incident("<incident-key>")
+  ```
+
 ### Deprecated
 
 - Using `new` on `Pagerduty` ([#64]). This works, but will be removed in the
@@ -48,6 +60,19 @@ The format is based on [Keep a Changelog], and this project adheres to
   ```
 
   Instead, use the new `Pagerduty.build` method (see above).
+
+- The `get_incident` method is now deprecated ([#67]). It still works, but
+  will be removed in the next major release. Please migrate to the new
+  `incident` method, that works in exactly the same way.
+
+  ```diff
+  pagerduty = Pagerduty.new("<integration-key>")
+  - incident = pagerduty.get_incident("<incident-key>")
+  + incident = pagerduty.incident("<incident-key>")
+  incident.trigger("<incident description>")
+  incident.acknowledge
+  incident.resolve
+  ```
 
 ### Changed
 
@@ -85,14 +110,15 @@ The format is based on [Keep a Changelog], and this project adheres to
   And this is even better:
 
   ```ruby
-  incident1 = pagerduty.get_incident('one').trigger('first incident')
-  incident2 = pagerduty.get_incident('two').trigger('second incident')
+  incident1 = pagerduty.incident('one').trigger('first incident')
+  incident2 = pagerduty.incident('two').trigger('second incident')
   ```
 
 [Unreleased]: https://github.com/envato/pagerduty/compare/v2.1.3...HEAD
 [events-v2-docs]: https://v2.developer.pagerduty.com/docs/send-an-event-events-api-v2
 [#64]: https://github.com/envato/pagerduty/pull/64
 [#66]: https://github.com/envato/pagerduty/pull/66
+[#67]: https://github.com/envato/pagerduty/pull/67
 
 ## [2.1.3] - 2020-02-10
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ incident.acknowledge(
 
 # Provide a client defined incident key
 # (this can be used to update existing incidents)
-incident = pagerduty.get_incident("<incident-key>")
+incident = pagerduty.incident("<incident-key>")
 incident.trigger("Description of the event")
 incident.acknowledge
 incident.resolve

--- a/lib/pagerduty/events_api_v1.rb
+++ b/lib/pagerduty/events_api_v1.rb
@@ -110,7 +110,7 @@ module Pagerduty
     #
     # @raise [ArgumentError] If incident_key is nil
     #
-    def get_incident(incident_key)
+    def incident(incident_key)
       raise ArgumentError, "incident_key is nil" if incident_key.nil?
 
       Incident.new(@config.merge(incident_key: incident_key))

--- a/lib/pagerduty/legacy.rb
+++ b/lib/pagerduty/legacy.rb
@@ -13,6 +13,8 @@ Pagerduty::EventsApiV1::Incident.class_eval do
 end
 
 Pagerduty::EventsApiV1.class_eval do
+  alias_method :get_incident, :incident
+
   def service_key
     @config[:integration_key]
   end

--- a/spec/pagerduty/events_api_v1_spec.rb
+++ b/spec/pagerduty/events_api_v1_spec.rb
@@ -136,8 +136,8 @@ RSpec.describe Pagerduty do
     end
   end
 
-  describe "#get_incident" do
-    When(:incident) { pagerduty.get_incident(incident_key) }
+  describe "#incident" do
+    When(:incident) { pagerduty.incident(incident_key) }
 
     context "a valid incident_key" do
       Given(:incident_key) { "a-test-incident-key" }
@@ -152,7 +152,7 @@ RSpec.describe Pagerduty do
   end
 
   describe Pagerduty::EventsApiV1::Incident do
-    Given(:incident) { pagerduty.get_incident(incident_key) }
+    Given(:incident) { pagerduty.incident(incident_key) }
 
     Given(:incident_key) { "a-test-incident-key" }
 


### PR DESCRIPTION
It's not idiomatic to name a method `get_*` in Ruby. Let's rename the `get_incident` method to `incident`.

For backwards compatibility we can keep the `get_incident` method around for a major release to give people time to migrate.