### PR TITLE
Clarify how to specify an incident key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,14 +100,14 @@ The format is based on [Keep a Changelog], and this project adheres to
   Instead always use the pagerduty object when triggering new incidents (with
   new incident keys).
 
-  This works:
+  This works with the Events API V1:
 
   ```ruby
   incident1 = pagerduty.trigger('first incident', incident_key: 'one')
   incident2 = pagerduty.trigger('second incident', incident_key: 'two')
   ```
 
-  And this is even better:
+  And this is even better, as it works with both the Events API V1 and V2:
 
   ```ruby
   incident1 = pagerduty.incident('one').trigger('first incident')

--- a/lib/pagerduty.rb
+++ b/lib/pagerduty.rb
@@ -68,6 +68,7 @@ module Pagerduty
     unless config.key?(:integration_key)
       raise ArgumentError, "integration_key not provided"
     end
+    raise ArgumentError, "incident_key provided" if config.key?(:incident_key)
 
     version = config.fetch(:api_version) do
       raise ArgumentError, "api_version not provided"

--- a/spec/pagerduty/events_api_v2_spec.rb
+++ b/spec/pagerduty/events_api_v2_spec.rb
@@ -130,6 +130,20 @@ RSpec.describe Pagerduty do
         }
       end
 
+      context "given a dedup_key option" do
+        When(:trigger) {
+          pagerduty.trigger(simple_incident_details.merge(dedup_key: "key"))
+        }
+        Then { expect(trigger).to have_failed ArgumentError }
+      end
+
+      context "given an incident_key option" do
+        When(:trigger) {
+          pagerduty.trigger(simple_incident_details.merge(incident_key: "key"))
+        }
+        Then { expect(trigger).to have_failed ArgumentError }
+      end
+
       context "configured with an HTTP proxy" do
         Given(:http_proxy) {
           {
@@ -344,7 +358,16 @@ RSpec.describe Pagerduty do
         end
 
         context "given a dedup_key option" do
-          When(:trigger) { incident.trigger(dedup_key: "key") }
+          When(:trigger) {
+            incident.trigger(simple_incident_details.merge(dedup_key: "key"))
+          }
+          Then { expect(trigger).to have_failed ArgumentError }
+        end
+
+        context "given an incident_key option" do
+          When(:trigger) {
+            incident.trigger(simple_incident_details.merge(incident_key: "key"))
+          }
           Then { expect(trigger).to have_failed ArgumentError }
         end
       end

--- a/spec/pagerduty_spec.rb
+++ b/spec/pagerduty_spec.rb
@@ -39,5 +39,14 @@ RSpec.describe Pagerduty do
                                      "api_version 0 not supported")
       }
     end
+
+    context "given an incident key" do
+      Given(:config) {
+        { incident_key: "ik", integration_key: "test-key", api_version: 1 }
+      }
+      Then {
+        expect(build).to have_raised(ArgumentError, "incident_key provided")
+      }
+    end
   end
 end


### PR DESCRIPTION
The best way to specify a Pagerduty incident key is via the `incident` method.

Let's raise an error if it's provided via an unsupported mechanism.