### PR TITLE
Link to PagerDuty documentation for obtaining an integration key

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Provides a lightweight Ruby interface for calling the [PagerDuty Events
 API][events-v2-docs].
 
-[events-v2-docs]: https://v2.developer.pagerduty.com/docs/send-an-event-events-api-v2
+[events-v2-docs]: https://developer.pagerduty.com/docs/events-api-v2/overview/
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ Or install it yourself as:
 
 ## Usage
 
+First, obtain an Events API integration key from PagerDuty. Follow the
+[instructions][integration-key-documentation] in PagerDuty's documentation to
+procure one.
+
+[integration-key-documentation]: https://support.pagerduty.com/docs/services-and-integrations#create-a-generic-events-api-integration
+
+
 ### Events API V2
 
 ```ruby


### PR DESCRIPTION
To help engineers getting started with the gem, link to PagerDuty's documentation detailing how to obtain an Events API integration key.