### PR TITLE
Resolve Net::HTTPServerException depreciation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,14 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 - Use GitHub Actions for CI build instead of TravisCI ([#73]).
 
+### Fixed
+
+- Resolved `Net::HTTPServerException` deprecation warning in test suite([#75]).
+
 [Unreleased]: https://github.com/envato/pagerduty/compare/v3.0.0...HEAD
 [#73]: https://github.com/envato/pagerduty/pull/73
 [#74]: https://github.com/envato/pagerduty/pull/74
+[#75]: https://github.com/envato/pagerduty/pull/75
 
 ## [3.0.0] - 2020-04-20
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ begin
     source:   "source",
     severity: "critical"
   )
-rescue Net::HTTPServerException => error
+rescue Net::HTTPClientException => error
   error.response.code    #=> "400"
   error.response.message #=> "Bad Request"
   error.response.body    #=> "{\"status\":\"invalid event\",\"message\":\"Event object is invalid\",\"errors\":[\"Service key is the wrong length (should be 32 characters)\"]}"

--- a/spec/pagerduty/events_api_v1_spec.rb
+++ b/spec/pagerduty/events_api_v1_spec.rb
@@ -128,10 +128,10 @@ RSpec.describe Pagerduty do
         Given {
           allow(transport)
             .to receive(:send_payload)
-            .and_raise(Net::HTTPServerException.new(nil, nil))
+            .and_raise(Net::HTTPClientException.new(nil, nil))
         }
         When(:incident) { pagerduty.trigger("description") }
-        Then { expect(incident).to have_raised Net::HTTPServerException }
+        Then { expect(incident).to have_raised Net::HTTPClientException }
       end
     end
   end
@@ -226,10 +226,10 @@ RSpec.describe Pagerduty do
           Given {
             allow(transport)
               .to receive(:send_payload)
-              .and_raise(Net::HTTPServerException.new(nil, nil))
+              .and_raise(Net::HTTPClientException.new(nil, nil))
           }
           When(:acknowledge) { incident.acknowledge }
-          Then { expect(acknowledge).to have_failed Net::HTTPServerException }
+          Then { expect(acknowledge).to have_failed Net::HTTPClientException }
         end
       end
     end
@@ -301,10 +301,10 @@ RSpec.describe Pagerduty do
           Given {
             allow(transport)
               .to receive(:send_payload)
-              .and_raise(Net::HTTPServerException.new(nil, nil))
+              .and_raise(Net::HTTPClientException.new(nil, nil))
           }
           When(:resolve) { incident.resolve }
-          Then { expect(resolve).to have_failed Net::HTTPServerException }
+          Then { expect(resolve).to have_failed Net::HTTPClientException }
         end
       end
     end

--- a/spec/pagerduty/events_api_v2_spec.rb
+++ b/spec/pagerduty/events_api_v2_spec.rb
@@ -198,10 +198,10 @@ RSpec.describe Pagerduty do
         Given {
           allow(transport)
             .to receive(:send_payload)
-            .and_raise(Net::HTTPServerException.new(nil, nil))
+            .and_raise(Net::HTTPClientException.new(nil, nil))
         }
         When(:incident) { pagerduty.trigger(simple_incident_details) }
-        Then { expect(incident).to have_raised Net::HTTPServerException }
+        Then { expect(incident).to have_raised Net::HTTPClientException }
       end
     end
   end
@@ -272,10 +272,10 @@ RSpec.describe Pagerduty do
           Given {
             allow(transport)
               .to receive(:send_payload)
-              .and_raise(Net::HTTPServerException.new(nil, nil))
+              .and_raise(Net::HTTPClientException.new(nil, nil))
           }
           When(:acknowledge) { incident.acknowledge }
-          Then { expect(acknowledge).to have_failed Net::HTTPServerException }
+          Then { expect(acknowledge).to have_failed Net::HTTPClientException }
         end
       end
     end
@@ -325,10 +325,10 @@ RSpec.describe Pagerduty do
           Given {
             allow(transport)
               .to receive(:send_payload)
-              .and_raise(Net::HTTPServerException.new(nil, nil))
+              .and_raise(Net::HTTPClientException.new(nil, nil))
           }
           When(:resolve) { incident.resolve }
-          Then { expect(resolve).to have_failed Net::HTTPServerException }
+          Then { expect(resolve).to have_failed Net::HTTPClientException }
         end
       end
     end

--- a/spec/pagerduty/http_transport_spec.rb
+++ b/spec/pagerduty/http_transport_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Pagerduty::HttpTransport do
 
       context "PagerDuty responds with HTTP bad request" do
         Given { allow(http).to receive(:request).and_return(bad_request) }
-        Then { expect(response).to have_raised Net::HTTPServerException }
+        Then { expect(response).to have_raised Net::HTTPClientException }
       end
     end
 

--- a/spec/pagerduty/legacy_spec.rb
+++ b/spec/pagerduty/legacy_spec.rb
@@ -113,10 +113,10 @@ RSpec.describe Pagerduty do
         Given {
           allow(transport)
             .to receive(:send_payload)
-            .and_raise(Net::HTTPServerException.new(nil, nil))
+            .and_raise(Net::HTTPClientException.new(nil, nil))
         }
         When(:incident) { pagerduty.trigger("description") }
-        Then { expect(incident).to have_raised Net::HTTPServerException }
+        Then { expect(incident).to have_raised Net::HTTPClientException }
       end
     end
   end
@@ -213,10 +213,10 @@ RSpec.describe Pagerduty do
           Given {
             allow(transport)
               .to receive(:send_payload)
-              .and_raise(Net::HTTPServerException.new(nil, nil))
+              .and_raise(Net::HTTPClientException.new(nil, nil))
           }
           When(:acknowledge) { incident.acknowledge }
-          Then { expect(acknowledge).to have_failed Net::HTTPServerException }
+          Then { expect(acknowledge).to have_failed Net::HTTPClientException }
         end
       end
     end
@@ -288,10 +288,10 @@ RSpec.describe Pagerduty do
           Given {
             allow(transport)
               .to receive(:send_payload)
-              .and_raise(Net::HTTPServerException.new(nil, nil))
+              .and_raise(Net::HTTPClientException.new(nil, nil))
           }
           When(:resolve) { incident.resolve }
-          Then { expect(resolve).to have_failed Net::HTTPServerException }
+          Then { expect(resolve).to have_failed Net::HTTPClientException }
         end
       end
     end

--- a/spec/support/http_client_exception.rb
+++ b/spec/support/http_client_exception.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "net/https"
+
+# Net::HTTPClientException was introduced in Ruby 2.6 as a better named
+# replacement for Net::HTTPServerException
+#
+# https://bugs.ruby-lang.org/issues/14688
+#
+# This allows use of the new class name while running the test suite on Rubies
+# older than version 2.6.
+unless defined?(Net::HTTPClientException)
+  Net::HTTPClientException = Net::HTTPServerException
+end


### PR DESCRIPTION
This resolves the depreciation warning generated when running the test suite:

> warning: constant Net::HTTPServerException is deprecated

Context: `Net::HTTPClientException` was introduced in Ruby 2.6 as a better named replacement for `Net::HTTPServerException`.

https://bugs.ruby-lang.org/issues/14688