### PR TITLE
Rename default branch to 'main'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 ### Changed
 
 - Use GitHub Actions for CI build instead of TravisCI ([#73]).
+- The default git branch has been renamed to `main`.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # pagerduty
 
-[![License MIT](https://img.shields.io/badge/license-MIT-brightgreen.svg)](https://github.com/envato/pagerduty/blob/master/LICENSE.txt)
+[![License MIT](https://img.shields.io/badge/license-MIT-brightgreen.svg)](https://github.com/envato/pagerduty/blob/HEAD/LICENSE.txt)
 [![Gem Version](https://img.shields.io/gem/v/pagerduty.svg?maxAge=2592000)](https://rubygems.org/gems/pagerduty)
 [![Gem Downloads](https://img.shields.io/gem/dt/pagerduty.svg?maxAge=2592000)](https://rubygems.org/gems/pagerduty)
-[![Build Status](https://github.com/envato/pagerduty/workflows/build/badge.svg?branch=master)](https://github.com/envato/pagerduty/actions)
+[![Build Status](https://github.com/envato/pagerduty/workflows/build/badge.svg?branch=main)](https://github.com/envato/pagerduty/actions?query=workflow%3Abuild+branch%3Amain)
 
 Provides a lightweight Ruby interface for calling the [PagerDuty Events
 API][events-v2-docs].


### PR DESCRIPTION
To be more inclusive, the default git branch has been renamed to `main`.

- Update the badge links to point to this branch,
- Log the change in the `CHANGELOG` document.