### PR TITLE
Drop explicit json runtime dependency & bump Ruby requirement to >= 2.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '2.1'
-          - '2.2'
           - '2.3'
           - '2.4'
           - '2.5'

--- a/pagerduty.gemspec
+++ b/pagerduty.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files -z`.split("\x0").select do |f|
     f.match(%r{^(?:README|LICENSE|CHANGELOG|lib/)})
   end
+  gem.required_ruby_version = ">= 2.3"
 
-  gem.add_runtime_dependency "json", ">= 1.7.7"
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec-given"


### PR DESCRIPTION
### Context

The json gem has been part of the Ruby standard library since version 1.9. Projects no-longer need to declare an explicit dependency on the json gem. Rather, they can assume it's available.

### Change

- Drop the explicit json runtime dependency.
- Bump required Ruby to version 2.3 or higher.