### PR TITLE
Set the required ruby version to 2.6

### DIFF
--- a/pagerduty.gemspec
+++ b/pagerduty.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files -z`.split("\x0").select do |f|
     f.match(%r{^(?:README|LICENSE|CHANGELOG|lib/)})
   end
-  gem.required_ruby_version = ">= 2.3"
+  gem.required_ruby_version = ">= 2.6"
 
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "rake"


### PR DESCRIPTION
Introducing a dependency on `Net::HTTPClientException` means that gem
consumers must either use Ruby2.6 or set the constant's alias themselves.