### PR TITLE
CI: add Ruby 4.0 and 3.4 to the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['3.3', '3.2', '3.1', '3.0', '2.7', '2.6', '2.5', '2.4', '2.3']
+        ruby: ['4.0', '3.4', '3.3', '3.2', '3.1', '3.0', '2.7', '2.6', '2.5', '2.4', '2.3']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Test on Ruby 3.4, and 4.0 in the CI build ([#88]).
+
 [Unreleased]: https://github.com/envato/pagerduty/compare/v4.0.1...HEAD
+[#88]: https://github.com/envato/pagerduty/pull/88
 
 ## [4.0.1] - 2024-02-17
 


### PR DESCRIPTION
Ruby [4.0](https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/) and [3.4](https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/) have been released! Let's add them to the CI build matrix for confidence in compatibility.